### PR TITLE
CD-231823 CD-231827 Service retry once by getting a new service token…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,18 +16,24 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <org.slf4j.version>1.7.26</org.slf4j.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.26</version>
+      <version>${org.slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${org.slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/coupa/sand/AllowedResponse.java
+++ b/src/main/java/com/coupa/sand/AllowedResponse.java
@@ -1,5 +1,6 @@
 package com.coupa.sand;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -26,7 +27,7 @@ public class AllowedResponse {
     private String iAud = null;
     private String iIat = null;
     private String iExp = null;
-    private String iExt = null;
+    private Map<String, Object> iExt = null;
 
     /**
      * Constructor that will just set if the response is allowed or not
@@ -74,7 +75,7 @@ public class AllowedResponse {
             iAud = (String)mapResponse.get(RESPONSE_FIELD_AUD);
             iIat = (String)mapResponse.get(RESPONSE_FIELD_IAT);
             iExp = (String)mapResponse.get(RESPONSE_FIELD_EXP);
-            iExt = (String)mapResponse.get(RESPONSE_FIELD_EXT);
+            iExt = (Map<String, Object>)mapResponse.get(RESPONSE_FIELD_EXT);
         }
         else {
             iAllowed = false;
@@ -137,11 +138,31 @@ public class AllowedResponse {
         iExp = exp;
     }
 
-    public String getExt() {
+    public Map<String, Object> getExt() {
         return iExt;
     }
 
-    public void setExt(String ext) {
+    public void setExt(Map<String, Object> ext) {
         iExt = ext;
+    }
+
+    /**
+     * Checks if the response expiry time has passsed.
+     * If the response doesn't have an expiry time, it's considered not expired.
+     *
+     * @return boolean if the response has expired.
+     */
+    public boolean isExpired() {
+        String expires = getExp();
+  
+        if (expires != null) {
+            OffsetDateTime timeExpires = OffsetDateTime.parse(expires);
+            OffsetDateTime timeNow = OffsetDateTime.now(timeExpires.getOffset());
+  
+            return timeNow.isAfter(timeExpires);
+        }
+  
+        //Denied token's response will not expire and will get cleaned up by cache's default expiry time.
+        return false;
     }
 }

--- a/src/main/java/com/coupa/sand/AllowedResponseTest.java
+++ b/src/main/java/com/coupa/sand/AllowedResponseTest.java
@@ -1,0 +1,29 @@
+package com.coupa.sand;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class AllowedResponseTest {
+
+  @Test
+  public void testIsExpired() {
+    AllowedResponse ar = new AllowedResponse(false);
+    
+    assertNull(ar.getExp());
+    assertFalse(ar.isExpired());
+    
+    ar.setExp("1980-02-09T10:05:53.637844877Z");
+    assertTrue(ar.isExpired());
+
+    ar.setExp("3000-02-09T10:05:53.637844877Z");
+    assertFalse(ar.isExpired());
+    
+    ar.setExp("1980-02-09T20:40:12.055455+08:00");
+    assertTrue(ar.isExpired());
+
+    ar.setExp("3000-02-09T20:40:12.055455+08:00");
+    assertFalse(ar.isExpired());
+  }
+
+}

--- a/src/main/java/com/coupa/sand/ClientTest.java
+++ b/src/main/java/com/coupa/sand/ClientTest.java
@@ -1,0 +1,19 @@
+package com.coupa.sand;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class ClientTest {
+
+  @Test
+  public void testGetToken() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testGetOAuthToken() {
+    fail("Not yet implemented");
+  }
+
+}

--- a/src/main/java/com/coupa/sand/TokenResponse.java
+++ b/src/main/java/com/coupa/sand/TokenResponse.java
@@ -41,14 +41,7 @@ public class TokenResponse {
       scopes = scope.split(" ");
 
       Object expire = mapResponse.get(EXPIRES_IN);
-      if (expire instanceof Long) {
-          expiresIn = (long) expire;
-      } else if (expire instanceof String) {
-          expiresIn = Long.parseLong((String) expire);
-      } else {
-          expiresIn = DEFAULT_TOKEN_EXPIRES_IN_SECONDS;
-      }
-      expiresAt = System.currentTimeMillis() + expiresIn * 1_000L;
+      setExpiresAt(System.currentTimeMillis(), expire);
   }
 
   public boolean isExpired() {
@@ -75,15 +68,26 @@ public class TokenResponse {
       return expiresIn;
   }
 
-  public void setExpiresIn(long expiresIn) {
-      this.expiresIn = expiresIn;
-  }
-
   public String getTokenType() {
       return tokenType;
   }
 
   public void setTokenType(String tokenType) {
       this.tokenType = tokenType;
+  }
+  
+  public void setExpiresAt(long currentTime, Object expire) {
+      if (expire instanceof Long) {
+          expiresIn = (long) expire;
+      } else if (expire instanceof String) {
+          expiresIn = Long.parseLong((String) expire);
+      } else {
+          expiresIn = DEFAULT_TOKEN_EXPIRES_IN_SECONDS;
+      }
+      expiresAt = currentTime + expiresIn * 1_000L;
+  }
+  
+  public long getExpiresAt() {
+      return expiresAt;
   }
 }

--- a/src/main/java/com/coupa/sand/TokenResponseTest.java
+++ b/src/main/java/com/coupa/sand/TokenResponseTest.java
@@ -1,0 +1,41 @@
+package com.coupa.sand;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TokenResponseTest {
+  HashMap<String, Object> data;
+  
+  @Before
+  public void setUp() throws Exception {
+    data = new HashMap<String, Object>();
+    data.put("access_token", "abcde");
+    data.put("expires_in", 3599L);
+    data.put("scope", "some_scope");
+    data.put("token_type", "bearer");
+  }
+
+  @Test
+  public void testIsExpired() {
+    TokenResponse tr = new TokenResponse(data);
+    assertFalse(tr.isExpired());
+    
+    data.put("expires_in", -3599L);
+    tr = new TokenResponse(data);
+    assertTrue(tr.isExpired());
+  }
+
+  @Test
+  public void testSetExpiresAt() {
+    TokenResponse tr = new TokenResponse(data);
+    
+    tr.setExpiresAt(0L, 3L);
+    assertEquals(tr.getExpiresIn(), 3L);
+    assertEquals(tr.getExpiresAt(), 3000L);
+  }
+
+}


### PR DESCRIPTION
… when encountering 401 verifying a token.

Fixed AllowedResponse's iExt type, which should be a map instead of a string. This caused a patch on Sand v2 https://github.com/coupa/hydra-sand/pull/35

Fixed service token response max cache size to 100,000. The old value of 1000 is too small (especially for Kafka).

Made the cache size and expiry time configurable.

Tested locally the cache operations. Looks good.

- [x] @abdulchaudhrycoupa 
- [x] @sushmanivargi 